### PR TITLE
Add option to not trade at startup advice

### DIFF
--- a/app.js
+++ b/app.js
@@ -25,6 +25,7 @@ app.prototype.launchTrader = function() {
 
   this.logger.log('----------------------------------------------------');
   this.logger.log('Launching trader module.');
+  this.logger.log('Trade at start = ' + config.tradeAtStart);
   this.logger.log('----------------------------------------------------');
   this.app = require('./apps/trader.js');
   this.appListener();

--- a/apps/trader.js
+++ b/apps/trader.js
@@ -71,7 +71,13 @@ var trader = function() {
 
   advisor.on('advice', function(result) {
 
-    this.logger.log('Advice: ' + result.advice + ' (' + result.indicatorValue + ')');
+    var indicatorValueStr = result.indicatorValue ? ' (' + result.indicatorValue + ')' : '';
+    var adviceStr = result.isStart ? 'Start advice: ' : 'Advice: ';
+    this.logger.log(adviceStr + result.advice + indicatorValueStr);
+
+    if (!config.tradeAtStart && result.isStart) {
+      return false;
+    }
 
     if(result.advice === 'buy') {
 

--- a/config.sample.js
+++ b/config.sample.js
@@ -4,6 +4,9 @@ var config = {};
 
 //------------------------------EnableRealTrading
 config.tradingEnabled = false;
+// If false trading is simulated, candles are still aggregated
+config.tradeAtStart = false;
+// If true a trade is made immediately if the advice is either buy or sell
 //------------------------------EnableRealTrading
 
 //------------------------------exchangeSettings

--- a/services/tradingadvisor.js
+++ b/services/tradingadvisor.js
@@ -43,7 +43,10 @@ advisor.prototype.start = function(callback) {
 
 	this.storage.getLastNCompleteAggregatedCandleSticks(1000, this.candleStickSize, function(err, candleSticks) {
 
-		this.latestTradeAdvice = {advice: 'hold'};
+		this.latestTradeAdvice = {
+			advice: 'hold',
+			isStart: true
+		};
 
 		for(var i = 0; i < candleSticks.length; i++) {
 
@@ -51,11 +54,11 @@ advisor.prototype.start = function(callback) {
 
 			if(['buy', 'sell', 'hold'].indexOf(result.advice) >= 0) {
 				if(['buy', 'sell'].indexOf(result.advice) >= 0) {
-					this.latestTradeAdvice = result;
+					_.extend(this.latestTradeAdvice, result);
 				}
 			} else {
-				var err = new Error('Invalid advice from indicator, should be either: buy, sell or hold.');
-				this.logger.error(err.stack);
+				var _err = new Error('Invalid advice from indicator, should be either: buy, sell or hold.');
+				this.logger.error(_err.stack);
 				process.exit();
 			}
 


### PR DESCRIPTION
When restarting the bot after, say, changes to to the indicator settings an order created at startup may not be desirable.
This also marks the startup advice as such.